### PR TITLE
NO-JIRA: Install cifs-utils in image

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -5,7 +5,7 @@ RUN make smb ARCH=$(go env GOARCH) && cp _output/$(go env GOARCH)/smbplugin .
 
 FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/csi-driver-smb/smbplugin /bin/smbplugin
-RUN yum install -y util-linux ca-certificates && yum clean all && rm -rf /var/cache/yum
+RUN yum install -y util-linux ca-certificates cifs-utils && yum clean all && rm -rf /var/cache/yum
 
 LABEL description="SMB CSI Driver"
 


### PR DESCRIPTION
Without `cifs-utils` the driver doesn't load IP-address of smb-server to the kernel. This leads to the error:
```
[Wed Apr  3 06:16:14 2024] CIFS: Unable to determine destination address
```