### PR TITLE
STOR-1743: Adapt e2e tests for OCP

### DIFF
--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -61,6 +61,10 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 			Volumes: []testsuites.VolumeDetails{
 				{
 					ClaimSize: "10Gi",
+					MountOptions: []string{
+						"dir_mode=0777",
+						"file_mode=0777",
+					},
 					VolumeMount: testsuites.VolumeMountDetails{
 						NameGenerate:      "test-volume-",
 						MountPathGenerate: "/mnt/test-",
@@ -203,6 +207,10 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 			Volumes: []testsuites.VolumeDetails{
 				{
 					ClaimSize: "10Gi",
+					MountOptions: []string{
+						"dir_mode=0777",
+						"file_mode=0777",
+					},
 					VolumeMount: testsuites.VolumeMountDetails{
 						NameGenerate:      "test-volume-",
 						MountPathGenerate: "/mnt/test-",

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -38,50 +38,65 @@ import (
 )
 
 const (
-	kubeconfigEnvVar  = "KUBECONFIG"
-	reportDirEnv      = "ARTIFACTS"
-	testWindowsEnvVar = "TEST_WINDOWS"
-	defaultReportDir  = "test/e2e"
+	kubeconfigEnvVar             = "KUBECONFIG"
+	reportDirEnv                 = "ARTIFACTS"
+	testWindowsEnvVar            = "TEST_WINDOWS"
+	defaultReportDir             = "test/e2e"
+	testSmbSourceEnvVar          = "TEST_SMB_SOURCE"
+	testSmbSecretNameEnvVar      = "TEST_SMB_SECRET_NAME"
+	testSmbSecretNamespaceEnvVar = "TEST_SMB_SECRET_NAMESPACE"
+	defaultSmbSource             = "//smb-server.default.svc.cluster.local/share"
+	defaultSmbSecretName         = "smbcreds"
+	defaultSmbSecretNamespace    = "default"
 )
 
 var (
 	smbDriver                     *smb.Driver
 	isWindowsCluster              = os.Getenv(testWindowsEnvVar) != ""
 	defaultStorageClassParameters = map[string]string{
-		"source": "//smb-server.default.svc.cluster.local/share",
-		"csi.storage.k8s.io/provisioner-secret-name":      "smbcreds",
-		"csi.storage.k8s.io/provisioner-secret-namespace": "default",
-		"csi.storage.k8s.io/node-stage-secret-name":       "smbcreds",
-		"csi.storage.k8s.io/node-stage-secret-namespace":  "default",
+		"source": getSmbTestEnvVarValue(testSmbSourceEnvVar, defaultSmbSource),
+		"csi.storage.k8s.io/provisioner-secret-name":      getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName),
+		"csi.storage.k8s.io/provisioner-secret-namespace": getSmbTestEnvVarValue(testSmbSecretNamespaceEnvVar, defaultSmbSecretNamespace),
+		"csi.storage.k8s.io/node-stage-secret-name":       getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName),
+		"csi.storage.k8s.io/node-stage-secret-namespace":  getSmbTestEnvVarValue(testSmbSecretNamespaceEnvVar, defaultSmbSecretNamespace),
 	}
 	subDirStorageClassParameters = map[string]string{
-		"source": "//smb-server.default.svc.cluster.local/share",
+		"source": getSmbTestEnvVarValue(testSmbSourceEnvVar, defaultSmbSource),
 		"subDir": "subDirectory-${pvc.metadata.name}",
-		"csi.storage.k8s.io/provisioner-secret-name":      "smbcreds",
-		"csi.storage.k8s.io/provisioner-secret-namespace": "default",
-		"csi.storage.k8s.io/node-stage-secret-name":       "smbcreds",
-		"csi.storage.k8s.io/node-stage-secret-namespace":  "default",
+		"csi.storage.k8s.io/provisioner-secret-name":      getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName),
+		"csi.storage.k8s.io/provisioner-secret-namespace": getSmbTestEnvVarValue(testSmbSecretNamespaceEnvVar, defaultSmbSecretNamespace),
+		"csi.storage.k8s.io/node-stage-secret-name":       getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName),
+		"csi.storage.k8s.io/node-stage-secret-namespace":  getSmbTestEnvVarValue(testSmbSecretNamespaceEnvVar, defaultSmbSecretNamespace),
 	}
 	retainStorageClassParameters = map[string]string{
-		"source": "//smb-server.default.svc.cluster.local/share",
-		"csi.storage.k8s.io/provisioner-secret-name":      "smbcreds",
-		"csi.storage.k8s.io/provisioner-secret-namespace": "default",
-		"csi.storage.k8s.io/node-stage-secret-name":       "smbcreds",
-		"csi.storage.k8s.io/node-stage-secret-namespace":  "default",
+		"source": getSmbTestEnvVarValue(testSmbSourceEnvVar, defaultSmbSource),
+		"csi.storage.k8s.io/provisioner-secret-name":      getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName),
+		"csi.storage.k8s.io/provisioner-secret-namespace": getSmbTestEnvVarValue(testSmbSecretNamespaceEnvVar, defaultSmbSecretNamespace),
+		"csi.storage.k8s.io/node-stage-secret-name":       getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName),
+		"csi.storage.k8s.io/node-stage-secret-namespace":  getSmbTestEnvVarValue(testSmbSecretNamespaceEnvVar, defaultSmbSecretNamespace),
 		"onDelete": "retain",
 	}
 	archiveStorageClassParameters = map[string]string{
-		"source": "//smb-server.default.svc.cluster.local/share",
-		"csi.storage.k8s.io/provisioner-secret-name":      "smbcreds",
-		"csi.storage.k8s.io/provisioner-secret-namespace": "default",
-		"csi.storage.k8s.io/node-stage-secret-name":       "smbcreds",
-		"csi.storage.k8s.io/node-stage-secret-namespace":  "default",
+		"source": getSmbTestEnvVarValue(testSmbSourceEnvVar, defaultSmbSource),
+		"csi.storage.k8s.io/provisioner-secret-name":      getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName),
+		"csi.storage.k8s.io/provisioner-secret-namespace": getSmbTestEnvVarValue(testSmbSecretNamespaceEnvVar, defaultSmbSecretNamespace),
+		"csi.storage.k8s.io/node-stage-secret-name":       getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName),
+		"csi.storage.k8s.io/node-stage-secret-namespace":  getSmbTestEnvVarValue(testSmbSecretNamespaceEnvVar, defaultSmbSecretNamespace),
+		"onDelete": "archive",
+	}
+	archiveSubDirStorageClassParameters = map[string]string{
+		"source": getSmbTestEnvVarValue(testSmbSourceEnvVar, defaultSmbSource),
+		"subDir": "${pvc.metadata.namespace}/${pvc.metadata.name}",
+		"csi.storage.k8s.io/provisioner-secret-name":      getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName),
+		"csi.storage.k8s.io/provisioner-secret-namespace": getSmbTestEnvVarValue(testSmbSecretNamespaceEnvVar, defaultSmbSecretNamespace),
+		"csi.storage.k8s.io/node-stage-secret-name":       getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName),
+		"csi.storage.k8s.io/node-stage-secret-namespace":  getSmbTestEnvVarValue(testSmbSecretNamespaceEnvVar, defaultSmbSecretNamespace),
 		"onDelete": "archive",
 	}
 	noProvisionerSecretStorageClassParameters = map[string]string{
-		"source": "//smb-server.default.svc.cluster.local/share",
-		"csi.storage.k8s.io/node-stage-secret-name":      "smbcreds",
-		"csi.storage.k8s.io/node-stage-secret-namespace": "default",
+		"source": getSmbTestEnvVarValue(testSmbSourceEnvVar, defaultSmbSource),
+		"csi.storage.k8s.io/node-stage-secret-name":      getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName),
+		"csi.storage.k8s.io/node-stage-secret-namespace": getSmbTestEnvVarValue(testSmbSecretNamespaceEnvVar, defaultSmbSecretNamespace),
 	}
 )
 
@@ -101,6 +116,11 @@ var _ = ginkgo.BeforeSuite(func() {
 	}
 	handleFlags()
 	framework.AfterReadingAllFlags(&framework.TestContext)
+
+	kubeconfig := os.Getenv(kubeconfigEnvVar)
+	options := smb.DriverOptions{
+		DriverName: smb.DefaultDriverName,
+	}
 
 	if testutil.IsRunningInProw() {
 		// Install SMB provisioner on cluster
@@ -128,17 +148,16 @@ var _ = ginkgo.BeforeSuite(func() {
 		execTestCmd([]testCmd{installSMBProvisioner, e2eBootstrap, createMetricsSVC})
 
 		nodeid := os.Getenv("nodeid")
-		kubeconfig := os.Getenv(kubeconfigEnvVar)
-		options := smb.DriverOptions{
+		options = smb.DriverOptions{
 			NodeID:               nodeid,
 			DriverName:           smb.DefaultDriverName,
 			EnableGetVolumeStats: false,
 		}
-		smbDriver = smb.NewDriver(&options)
-		go func() {
-			smbDriver.Run(fmt.Sprintf("unix:///tmp/csi-%s.sock", uuid.NewUUID().String()), kubeconfig, false)
-		}()
 	}
+	smbDriver = smb.NewDriver(&options)
+	go func() {
+		smbDriver.Run(fmt.Sprintf("unix:///tmp/csi-%s.sock", uuid.NewUUID().String()), kubeconfig, false)
+	}()
 
 	if isWindowsCluster {
 		err := os.Chdir("../..")
@@ -260,4 +279,13 @@ func skipIfTestingInWindowsCluster() {
 	if isWindowsCluster {
 		ginkgo.Skip("test case not supported by Windows clusters")
 	}
+}
+
+// getSmbTestEnvVarValue gets the smbTestEnvValue from env var if the var does not set use the defaultVarValue
+func getSmbTestEnvVarValue(envVarName string, defaultVarValue string) (smbTestEnvValue string) {
+	smbTestEnvValue = os.Getenv(envVarName)
+	if smbTestEnvValue == "" {
+		smbTestEnvValue = defaultVarValue
+	}
+	return
 }

--- a/test/utils/check_driver_pods_restart.sh
+++ b/test/utils/check_driver_pods_restart.sh
@@ -16,8 +16,11 @@
 
 set -e
 
+# Get the value of the environment variable or set a default value if it's empty
+CSI_DRIVER_INSTALLED_NAMESPACE="${CSI_DRIVER_INSTALLED_NAMESPACE:-kube-system}"
+
 echo "check the driver pods if restarts ..."
-restarts=$(kubectl get pods -n kube-system | grep smb | awk '{print $4}')
+restarts=$(kubectl get pods -n "${CSI_DRIVER_INSTALLED_NAMESPACE}" | grep smb | awk '{print $4}')
 for num in $restarts
 do
     if [ "$num" -ne "0" ]


### PR DESCRIPTION
### [STOR-1743](https://issues.redhat.com//browse/STOR-1743): Adapt e2e tests for OCP

- Use the samba server configuration consist with our `storage-create-csi-smb-ref` CI step
- Fix the nil pointer issue of the `smbDriver`
- Update several cases mountoption since previous upstream default smb server use the [PERMISSIONS: "0777"](https://github.com/kubernetes-csi/csi-driver-smb/blob/master/deploy/example/smb-provisioner/smb-server-lb.yaml#L37-L38) while our samba server does not use the server configuration

**Test records**

version: `smb-csi-driver-operator.v4.16.0-202404231239`

- All e2e test (also temporarily comment skipped one `should create a volume after driver restart [smb.csi.k8s.io]` which has disruptive option)

```console
$ go test -v -timeout=0 ./test/e2e -ginkgo.v -ginkgo.timeout=2h
------------------------------

Ran 12 of 12 Specs in 367.355 seconds
SUCCESS! -- 12 Passed | 0 Failed | 0 Pending | 0 Skipped
You're using deprecated Ginkgo functionality:
=============================================
  Support for custom reporters has been removed in V2.  Please read the documentation linked to below for Ginkgo's new behavior and for a migration path:
  Learn more at: https://onsi.github.io/ginkgo/MIGRATING_TO_V2#removed-custom-reporters

To silence deprecations that can be silenced set the following environment variable:
  ACK_GINKGO_DEPRECATIONS=2.13.0

--- PASS: TestE2E (367.36s)
PASS
ok      github.com/kubernetes-csi/csi-driver-smb/test/e2e       368.770s

```

- All e2e test

```console
$ go test -v -timeout=0 ./test/e2e -ginkgo.v -ginkgo.timeout=2h
------------------------------

Ran 11 of 12 Specs in 284.809 seconds
SUCCESS! -- 11 Passed | 0 Failed | 0 Pending | 1 Skipped
You're using deprecated Ginkgo functionality:
=============================================
  Support for custom reporters has been removed in V2.  Please read the documentation linked to below for Ginkgo's new behavior and for a migration path:
  Learn more at: https://onsi.github.io/ginkgo/MIGRATING_TO_V2#removed-custom-reporters

To silence deprecations that can be silenced set the following environment variable:
  ACK_GINKGO_DEPRECATIONS=2.13.0

--- PASS: TestE2E (284.81s)
PASS
ok      github.com/kubernetes-csi/csi-driver-smb/test/e2e       286.295s
```