### PR TITLE
OCPBUGS-34454: Updating ose-smb-csi-driver-container image to be consistent with ART for 4.17

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.21-openshift-4.17
+  tag: rhel-9-release-golang-1.22-openshift-4.17

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
 WORKDIR /go/src/github.com/openshift/csi-driver-smb
 COPY . .
 RUN make smb ARCH=$(go env GOARCH) && cp _output/$(go env GOARCH)/smbplugin .

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/kubernetes-csi/csi-driver-smb
 
-go 1.21
+go 1.22
 
-toolchain go1.21.7
+toolchain go1.22.1
 
 require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible

--- a/vendor/k8s.io/kubernetes/test/e2e/framework/testfiles/testdata/a/foo.txt
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/testfiles/testdata/a/foo.txt
@@ -1,1 +1,0 @@
-Hello World


### PR DESCRIPTION
The same as https://github.com/openshift/csi-driver-smb/pull/9 plus `go mod tidy ; go mod vendor`