### PR TITLE
STOR-2263: UPSTREAM: 928: test: use env var for CSI inline volume test secret

### DIFF
--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -539,9 +539,9 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 			ginkgo.Skip("Skip inline volume test on Windows Server 2022")
 		}
 
-		secretName := "smbcreds"
+		secretName := getSmbTestEnvVarValue(testSmbSecretNameEnvVar, defaultSmbSecretName)
 		ginkgo.By(fmt.Sprintf("creating secret %s in namespace %s", secretName, ns.Name))
-		tsecret := testsuites.CopyTestSecret(ctx, cs, "default", ns, defaultSmbSecretName)
+		tsecret := testsuites.CopyTestSecret(ctx, cs, getSmbTestEnvVarValue(testSmbSecretNamespaceEnvVar, defaultSmbSecretNamespace), ns, secretName)
 		tsecret.Create(ctx)
 		defer tsecret.Cleanup(ctx)
 
@@ -573,7 +573,7 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 			CSIDriver:  testDriver,
 			Pods:       pods,
 			Source:     defaultStorageClassParameters["source"],
-			SecretName: defaultSmbSecretName,
+			SecretName: secretName,
 			ReadOnly:   false,
 		}
 		test.Run(ctx, cs, ns)


### PR DESCRIPTION
- The `CSI inline volume` tests failed on downstream rebase test caused by we used the env vars for the smb server secret configuration while upsteam new test does not use the var, fixed the issue on upstream https://github.com/kubernetes-csi/csi-driver-smb/pull/928 .