### PR TITLE
gomod add .0 for go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-csi/csi-driver-smb
 
-go 1.24
+go 1.24.0
 
 godebug winsymlink=0
 


### PR DESCRIPTION
Task: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=68362304

Hermeto errors out if its missing the `.0` for go versions >= `1.22`