### PR TITLE
NO-JIRA: Add patch version to go directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-csi/csi-driver-smb
 
-go 1.22
+go 1.22.0
 
 toolchain go1.22.1
 


### PR DESCRIPTION
Recent CI update (https://github.com/openshift/release/pull/67369) made patch version necessary. Without this PR any change to release-4.18 branch of csi-driver-smb fails verfiy-deps CI job.